### PR TITLE
Using array_map to apply the sanitize_text_field on all fields.

### DIFF
--- a/includes/class-agentpress-taxonomies.php
+++ b/includes/class-agentpress-taxonomies.php
@@ -70,7 +70,7 @@ class AgentPress_Taxonomies {
 
 		/** This section handles the data if a new taxonomy is created */
 		if ( isset( $_REQUEST['action'] ) && 'create' === $_REQUEST['action'] && isset( $_POST['agentpress_taxonomy'] ) ) {
-			$this->create_taxonomy( sanitize_text_field( wp_unslash( $_POST['agentpress_taxonomy'] ) ) );
+			$this->create_taxonomy( array_map( 'sanitize_text_field', wp_unslash( $_POST['agentpress_taxonomy'] ) ) );
 		}
 
 		/** This section handles the data if a taxonomy is deleted */
@@ -80,7 +80,7 @@ class AgentPress_Taxonomies {
 
 		/** This section handles the data if a taxonomy is being edited */
 		if ( isset( $_REQUEST['action'] ) && 'edit' === $_REQUEST['action'] ) {
-			$this->edit_taxonomy( sanitize_text_field( wp_unslash( $_POST['agentpress_taxonomy'] ) ) );
+			$this->edit_taxonomy( array_map( 'sanitize_text_field', wp_unslash( $_POST['agentpress_taxonomy'] ) ) );
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
 

--- a/includes/views/create-tax.php
+++ b/includes/views/create-tax.php
@@ -61,7 +61,7 @@
 						<br />
 
 						<div class="row-actions">
-							<span class="edit"><a href="<?php echo esc_url( admin_url( 'admin.php?page=' . $this->menu_page . '&amp;view=edit&amp;id=' . esc_html( $id ) ) ); ?>"><?php esc_html_e( 'Edit', 'agentpress-listings' ); ?></a> | </span>
+							<span class="edit"><a href="<?php echo esc_url( admin_url( 'admin.php?page=' . $this->menu_page . '&amp;view=edit&amp;id=' . esc_html( $tax_id ) ) ); ?>"><?php esc_html_e( 'Edit', 'agentpress-listings' ); ?></a> | </span>
 							<span class="delete"><a class="delete-tag" href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=' . $this->menu_page . '&amp;action=delete&amp;id=' . esc_html( $tax_id ) ) ), 'agentpress-action_delete-taxonomy' ); ?>"><?php esc_html_e( 'Delete', 'agentpress-listings' ); ?></a></span>
 						</div>
 					<?php endif; ?>


### PR DESCRIPTION
This PR would resolve the bug when creating a new taxonomy. The plugin shows a message `Please complete all required fields.` but all the fields are properly filled.

Reported here: https://wordpress.org/support/topic/dont-let-create-taxonomies/

To test this PR:
 - Clone the branch  `hotfix/taxonomy-not-created` inside `wp-content/plugins/` directory;
 - Activate the plugin;
 - Add a new taxonomy by going to Listings > Register Taxonomies.