### PR TITLE
Fix video and map textarea

### DIFF
--- a/includes/class-agentpress-listings.php
+++ b/includes/class-agentpress-listings.php
@@ -33,6 +33,13 @@ class AgentPress_Listings {
 	public $property_details;
 
 	/**
+	 * Allowed tags.
+	 *
+	 * @var array
+	 */
+	public $allowed_tags;
+
+	/**
 	 * Construct Method.
 	 */
 	public function __construct() {
@@ -53,6 +60,45 @@ class AgentPress_Listings {
 					__( 'Bedrooms:', 'agentpress-listings' ) => '_listing_bedrooms',
 					__( 'Bathrooms:', 'agentpress-listings' ) => '_listing_bathrooms',
 					__( 'Basement:', 'agentpress-listings' ) => '_listing_basement',
+				),
+			)
+		);
+
+		$this->allowed_tags = apply_filters(
+			'agentpress_featured_listings_allowed_html',
+			array(
+				'p'      => array(),
+				'label'  => array(),
+				'br'     => array(),
+				'input'  => array(
+					'type'  => array(),
+					'name'  => array(),
+					'value' => array(),
+				),
+				'iframe' => array(
+					'allow'           => array(),
+					'allowfullscreen' => array(),
+					'csp'             => array(),
+					'height'          => array(),
+					'importance'      => array(),
+					'name'            => array(),
+					'referrerpolicy'  => array(),
+					'sandbox'         => array(),
+					'src'             => array(),
+					'srcdoc'          => array(),
+					'width'           => array(),
+					'align'           => array(),
+					'frameborder'     => array(),
+					'longdes'         => array(),
+					'marginheight'    => array(),
+					'marginwidth'     => array(),
+					'scrolling'       => array(),
+					'class'           => array(),
+					'id'              => array(),
+					'style'           => array(),
+					'title'           => array(),
+					'role'            => array(),
+					'data-*'          => array(),
 				),
 			)
 		);
@@ -169,10 +215,10 @@ class AgentPress_Listings {
 			return;
 		}
 
-		$property_details = array_map( 'sanitize_text_field', wp_unslash( $_POST['ap'] ) );
+		$property_details = array_map( 'wp_kses', [ wp_unslash( $_POST['ap'] ) ], [ $this->allowed_tags ] );
 
 		/** Store the custom fields */
-		foreach ( (array) $property_details as $key => $value ) {
+		foreach ( (array) $property_details[0] as $key => $value ) {
 
 			/** Save/Update/Delete */
 			if ( $value ) {

--- a/includes/class-agentpress-listings.php
+++ b/includes/class-agentpress-listings.php
@@ -215,7 +215,8 @@ class AgentPress_Listings {
 			return;
 		}
 
-		$property_details = array_map( 'wp_kses', [ wp_unslash( $_POST['ap'] ) ], [ $this->allowed_tags ] );
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$property_details = array_map( 'wp_kses', array( wp_unslash( $_POST['ap'] ) ), [ $this->allowed_tags ] );
 
 		/** Store the custom fields */
 		foreach ( (array) $property_details[0] as $key => $value ) {
@@ -285,10 +286,10 @@ class AgentPress_Listings {
 				break;
 			case 'listing_details':
 				foreach ( (array) $this->property_details['col1'] as $label => $key ) {
-					printf( '<b>%s</b> %s<br />', esc_html( $label ), esc_html( get_post_meta( $post->ID, $key, true ) ) );
+					printf( '<b>%s</b> %s<br />', esc_html( $label ), wp_kses( get_post_meta( $post->ID, $key, true ), $this->allowed_tags ) );
 				}
 				foreach ( (array) $this->property_details['col2'] as $label => $key ) {
-					printf( '<b>%s</b> %s<br />', esc_html( $label ), esc_html( get_post_meta( $post->ID, $key, true ) ) );
+					printf( '<b>%s</b> %s<br />', esc_html( $label ), wp_kses( get_post_meta( $post->ID, $key, true ), $this->allowed_tags ) );
 				}
 				break;
 			case 'listing_features':
@@ -319,13 +320,13 @@ class AgentPress_Listings {
 		$output .= '<div class="property-details-col1 one-half first">';
 
 		foreach ( (array) $this->property_details['col1'] as $label => $key ) {
-			$output .= sprintf( '<b>%s</b> %s<br />', esc_html( $label ), esc_html( get_post_meta( $post->ID, $key, true ) ) );
+			$output .= sprintf( '<b>%s</b> %s<br />', esc_html( $label ), wp_kses( get_post_meta( $post->ID, $key, true ), $this->allowed_tags ) );
 		}
 
 		$output .= '</div><div class="property-details-col2 one-half">';
 
 		foreach ( (array) $this->property_details['col2'] as $label => $key ) {
-			$output .= sprintf( '<b>%s</b> %s<br />', esc_html( $label ), esc_html( get_post_meta( $post->ID, $key, true ) ) );
+			$output .= sprintf( '<b>%s</b> %s<br />', esc_html( $label ), wp_kses( get_post_meta( $post->ID, $key, true ), $this->allowed_tags ) );
 		}
 
 		$output .= '</div><div class="clear">';

--- a/includes/class-agentpress-listings.php
+++ b/includes/class-agentpress-listings.php
@@ -216,7 +216,7 @@ class AgentPress_Listings {
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$property_details = array_map( 'wp_kses', array( wp_unslash( $_POST['ap'] ) ), [ $this->allowed_tags ] );
+		$property_details = array_map( 'wp_kses', array( wp_unslash( $_POST['ap'] ) ), array( $this->allowed_tags ) );
 
 		/** Store the custom fields */
 		foreach ( (array) $property_details[0] as $key => $value ) {

--- a/includes/views/listing-details-metabox.php
+++ b/includes/views/listing-details-metabox.php
@@ -18,19 +18,8 @@ $pattern = '<p><label>%s<br /><input type="text" name="ap[%s]" value="%s" /></la
 
 echo '<div style="width: 45%; float: left">';
 
-$allowed_tags = array(
-	'p'     => array(),
-	'label' => array(),
-	'br'    => array(),
-	'input' => array(
-		'type'  => array(),
-		'name'  => array(),
-		'value' => array(),
-	),
-);
-
 foreach ( (array) $this->property_details['col1'] as $label => $key ) {
-	printf( wp_kses( $pattern, $allowed_tags ), esc_html( $label ), esc_attr( $key ), esc_attr( genesis_get_custom_field( $key ) ) );
+	printf( wp_kses( $pattern, $this->allowed_tags ), esc_html( $label ), esc_attr( $key ), esc_attr( genesis_get_custom_field( $key ) ) );
 }
 	printf( '<p><a class="button" href="%s" onclick="%s">%s</a></p>', '#', 'ap_send_to_editor(\'[property_details]\')', esc_html__( 'Send to text editor', 'agentpress-listings' ) );
 
@@ -39,14 +28,14 @@ echo '</div>';
 echo '<div style="width: 45%; float: left;">';
 
 foreach ( (array) $this->property_details['col2'] as $label => $key ) {
-	printf( wp_kses( $pattern, $allowed_tags ), esc_html( $label ), esc_attr( $key ), esc_attr( genesis_get_custom_field( $key ) ) );
+	printf( wp_kses( $pattern, $this->allowed_tags ), esc_html( $label ), esc_attr( $key ), esc_attr( genesis_get_custom_field( $key ) ) );
 }
 
 echo '</div><br style="clear: both;" /><br /><br />';
 
 echo '<div style="width: 45%; float: left;">';
 
-printf( '<p><label>%1$s<br /><textarea name="ap[_listing_map]" rows="5" cols="18" style="%2$s">%3$s</textarea></label></p>', esc_html__( 'Enter Map Embed Code:', 'agentpress-listings' ), 'width: 99%;', wp_kses_post( genesis_get_custom_field( '_listing_map' ) ) );
+printf( '<p><label>%1$s<br /><textarea name="ap[_listing_map]" rows="5" cols="18" style="%2$s">%3$s</textarea></label></p>', esc_html__( 'Enter Map Embed Code:', 'agentpress-listings' ), 'width: 99%;', wp_kses( genesis_get_custom_field( '_listing_map' ), $this->allowed_tags ) );
 
 printf( '<p><a class="button" href="%s" onclick="%s">%s</a></p>', '#', 'ap_send_to_editor(\'[property_map]\')', esc_html__( 'Send to text editor', 'agentpress-listings' ) );
 
@@ -54,7 +43,7 @@ echo '</div>';
 
 echo '<div style="width: 45%; float: left;">';
 
-printf( '<p><label>%1$s:<br /><textarea name="ap[_listing_video]" rows="5" cols="18" style="%2$s">%3$s</textarea></label></p>', esc_html__( 'Enter Video Embed Code', 'agentpress-listings' ), 'width: 99%;', wp_kses_post( genesis_get_custom_field( '_listing_video' ) ) );
+printf( '<p><label>%1$s:<br /><textarea name="ap[_listing_video]" rows="5" cols="18" style="%2$s">%3$s</textarea></label></p>', esc_html__( 'Enter Video Embed Code', 'agentpress-listings' ), 'width: 99%;', wp_kses( genesis_get_custom_field( '_listing_video' ), $this->allowed_tags ) );
 
 printf( '<p><a class="button" href="%s" onclick="%s">%s</a></p>', '#', 'ap_send_to_editor(\'[property_video]\')', esc_html__( 'Send to text editor', 'agentpress-listings' ) );
 


### PR DESCRIPTION
This PR fixes the bug that affects the map and video embed textareas. We have updated the escaping function, which now is using `wp_kses` with some HTML tags allowed by default. Also, we've added a new filter `agentpress_featured_listings_allowed_html` where users could change these allowed tags.

Closes #39