### PR TITLE
Stop _listing_price_sortable meta being deleted when saving listings

### DIFF
--- a/includes/class-agentpress-listings.php
+++ b/includes/class-agentpress-listings.php
@@ -230,9 +230,8 @@ class AgentPress_Listings {
 		}
 
 		// Extra check for price that can create a sortable value.
-		if ( isset( $property_details['_listing_price'] ) && ! empty( $property_details['_listing_price'] ) ) {
-
-			$price_sortable = preg_replace( '/[^0-9\.]/', '', $property_details['_listing_price'] );
+		if ( isset( $property_details[0]['_listing_price'] ) && ! empty( $property_details[0]['_listing_price'] ) ) {
+			$price_sortable = preg_replace( '/[^0-9\.]/', '', $property_details[0]['_listing_price'] );
 			update_post_meta( $post_id, '_listing_price_sortable', floatval( $price_sortable ) );
 		} else {
 			delete_post_meta( $post_id, '_listing_price_sortable' );


### PR DESCRIPTION
Fixes #42.

## To test

1. Create a listing with a price.
2. Confirm the saved listing has a `_listing_price` and `_listing_price_sortable`:

```
❯ wp post meta list 7488
+---------+-------------------------+--------------+
| post_id | meta_key                | meta_value   |
+---------+-------------------------+--------------+
| 7488    | _edit_last              | 1            |
| 7488    | _edit_lock              | 1562778936:1 |
| 7488    | _listing_price          | 12345        |
| 7488    | _listing_price_sortable | 12345        |
+---------+-------------------------+--------------+
```

3. Edit the listing in any way (such as changing the title) and save again.
4. Confirm the `_listing_price` and `_listing_price_sortable` rows are still present.