### PR TITLE
AgentPress Listings 1.3.3

### DIFF
--- a/includes/class-agentpress-listings.php
+++ b/includes/class-agentpress-listings.php
@@ -230,9 +230,8 @@ class AgentPress_Listings {
 		}
 
 		// Extra check for price that can create a sortable value.
-		if ( isset( $property_details['_listing_price'] ) && ! empty( $property_details['_listing_price'] ) ) {
-
-			$price_sortable = preg_replace( '/[^0-9\.]/', '', $property_details['_listing_price'] );
+		if ( isset( $property_details[0]['_listing_price'] ) && ! empty( $property_details[0]['_listing_price'] ) ) {
+			$price_sortable = preg_replace( '/[^0-9\.]/', '', $property_details[0]['_listing_price'] );
 			update_post_meta( $post_id, '_listing_price_sortable', floatval( $price_sortable ) );
 		} else {
 			delete_post_meta( $post_id, '_listing_price_sortable' );

--- a/languages/agentpress-listings.pot
+++ b/languages/agentpress-listings.pot
@@ -1,14 +1,14 @@
-# Copyright (C) 2015 StudioPress
+# Copyright (C) 2019 StudioPress
 # This file is distributed under the GNU General Public License v2.0 (or later).
 msgid ""
 msgstr ""
-"Project-Id-Version: AgentPress Listings 1.2.6\n"
+"Project-Id-Version: AgentPress Listings 1.3.3\n"
 "Report-Msgid-Bugs-To: StudioPress <translations@studiopress.com>\n"
-"POT-Creation-Date: 2015-10-12 02:19:49+00:00\n"
+"POT-Creation-Date: 2019-07-11 15:33:03+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2015-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2019-MO-DA HO:MI+ZONE\n"
 "Last-Translator: StudioPress <translations@studiopress.com>\n"
 "Language-Team: English <translations@studiopress.com>\n"
 "X-Generator: grunt-wp-i18n 0.4.4\n"
@@ -24,340 +24,361 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 "X-Textdomain-Support: yes\n"
 
-#: includes/class-featured-listings-widget.php:12
+#: includes/class-agentpress-featured-listings-widget.php:23
 msgid "Display grid-style featured listings"
 msgstr ""
 
-#: includes/class-featured-listings-widget.php:14
+#: includes/class-agentpress-featured-listings-widget.php:31
 msgid "AgentPress - Featured Listings"
 msgstr ""
 
-#: includes/class-featured-listings-widget.php:91
-#: includes/class-listings.php:79 includes/class-listings.php:80
+#: includes/class-agentpress-featured-listings-widget.php:125
+#: includes/class-agentpress-listings.php:142
+#: includes/class-agentpress-listings.php:143
 msgid "View Listing"
 msgstr ""
 
-#: includes/class-featured-listings-widget.php:116
-#: includes/class-property-search-widget.php:77
+#: includes/class-agentpress-featured-listings-widget.php:169
+#: includes/class-agentpress-listings-search-widget.php:139
 msgid "Title:"
 msgstr ""
 
-#: includes/class-featured-listings-widget.php:118
+#: includes/class-agentpress-featured-listings-widget.php:171
 msgid "How many results should be returned?"
 msgstr ""
 
-#: includes/class-listings.php:28
-msgid "Price:"
-msgstr ""
-
-#: includes/class-listings.php:29
-msgid "Address:"
-msgstr ""
-
-#: includes/class-listings.php:30
-msgid "City:"
-msgstr ""
-
-#: includes/class-listings.php:31
-msgid "State:"
-msgstr ""
-
-#: includes/class-listings.php:32
-msgid "ZIP:"
-msgstr ""
-
-#: includes/class-listings.php:35
-msgid "MLS #:"
-msgstr ""
-
-#: includes/class-listings.php:36
-msgid "Square Feet:"
-msgstr ""
-
-#: includes/class-listings.php:37
-msgid "Bedrooms:"
-msgstr ""
-
-#: includes/class-listings.php:38
-msgid "Bathrooms:"
-msgstr ""
-
-#: includes/class-listings.php:39
-msgid "Basement:"
-msgstr ""
-
-#: includes/class-listings.php:72
-msgid "Listings"
-msgstr ""
-
-#: includes/class-listings.php:73
-msgid "Listing"
-msgstr ""
-
-#: includes/class-listings.php:74
-msgid "Add New"
-msgstr ""
-
-#: includes/class-listings.php:75
-msgid "Add New Listing"
-msgstr ""
-
-#: includes/class-listings.php:76 includes/views/create-tax.php:50
-msgid "Edit"
-msgstr ""
-
-#: includes/class-listings.php:77
-msgid "Edit Listing"
-msgstr ""
-
-#: includes/class-listings.php:78
-msgid "New Listing"
-msgstr ""
-
-#: includes/class-listings.php:81
-msgid "Search Listings"
-msgstr ""
-
-#: includes/class-listings.php:82
-msgid "No listings found"
-msgstr ""
-
-#: includes/class-listings.php:83
-msgid "No listings found in Trash"
-msgstr ""
-
-#: includes/class-listings.php:101
-msgid "Property Details"
-msgstr ""
-
-#: includes/class-listings.php:164
-msgid "Thumbnail"
-msgstr ""
-
-#: includes/class-listings.php:165
-msgid "Listing Title"
-msgstr ""
-
-#: includes/class-listings.php:166
-msgid "Details"
-msgstr ""
-
-#: includes/class-listings.php:167
-msgid "Features"
-msgstr ""
-
-#: includes/class-listings.php:168
-msgid "Categories"
-msgstr ""
-
-#: includes/class-listings.php:223
-msgid "Additional Features:"
-msgstr ""
-
-#: includes/class-listings.php:273
-msgid "Listing Search Results"
-msgstr ""
-
-#: includes/class-property-search-widget.php:12
+#: includes/class-agentpress-listings-search-widget.php:23
 msgid "Display property search dropdown"
 msgstr ""
 
-#: includes/class-property-search-widget.php:14
+#: includes/class-agentpress-listings-search-widget.php:32
 msgid "AgentPress - Listing Search"
 msgstr ""
 
-#: includes/class-property-search-widget.php:21
-#: includes/class-property-search-widget.php:69
+#: includes/class-agentpress-listings-search-widget.php:47
+#: includes/class-agentpress-listings-search-widget.php:129
 msgid "Search Properties"
 msgstr ""
 
-#: includes/class-property-search-widget.php:79
+#: includes/class-agentpress-listings-search-widget.php:141
 msgid "Include these taxonomies in the search widget"
 msgstr ""
 
-#: includes/class-property-search-widget.php:93
+#: includes/class-agentpress-listings-search-widget.php:156
 msgid "Button Text:"
 msgstr ""
 
-#: includes/class-taxonomies.php:39
+#: includes/class-agentpress-listings.php:51
+msgid "Price:"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:52
+msgid "Address:"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:53
+msgid "City:"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:54
+msgid "State:"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:55
+msgid "ZIP:"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:58
+msgid "MLS #:"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:59
+msgid "Square Feet:"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:60
+msgid "Bedrooms:"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:61
+msgid "Bathrooms:"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:62
+msgid "Basement:"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:135
+msgid "Listings"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:136
+msgid "Listing"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:137
+msgid "Add New"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:138
+msgid "Add New Listing"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:139 includes/views/create-tax.php:64
+msgid "Edit"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:140
+msgid "Edit Listing"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:141
+msgid "New Listing"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:144
+msgid "Search Listings"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:145
+msgid "No listings found"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:146
+msgid "No listings found in Trash"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:167
+msgid "Property Details"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:250
+msgid "Thumbnail"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:251
+msgid "Listing Title"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:252
+msgid "Details"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:253
+msgid "Features"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:254
+msgid "Categories"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:332
+msgid "Additional Features:"
+msgstr ""
+
+#: includes/class-agentpress-listings.php:408
+msgid "Listing Search Results"
+msgstr ""
+
+#: includes/class-agentpress-taxonomies.php:57
 msgid "Register Taxonomies"
 msgstr ""
 
-#: includes/class-taxonomies.php:87 includes/class-taxonomies.php:90
-#: includes/class-taxonomies.php:93 includes/class-taxonomies.php:190
-#: includes/class-taxonomies.php:192 includes/class-taxonomies.php:194
+#: includes/class-agentpress-taxonomies.php:118
+#: includes/class-agentpress-taxonomies.php:121
+#: includes/class-agentpress-taxonomies.php:124
+#: includes/class-agentpress-taxonomies.php:236
+#: includes/class-agentpress-taxonomies.php:240
+#: includes/class-agentpress-taxonomies.php:244
 msgid "Please complete all required fields."
 msgstr ""
 
-#: includes/class-taxonomies.php:101
+#: includes/class-agentpress-taxonomies.php:132
 msgid "You have given this taxonomy an invalid slug/ID. Please try again."
 msgstr ""
 
-#: includes/class-taxonomies.php:109 includes/class-taxonomies.php:203
-#: includes/class-taxonomies.php:274
+#: includes/class-agentpress-taxonomies.php:141
+#: includes/class-agentpress-taxonomies.php:255
+#: includes/class-agentpress-taxonomies.php:341
+#. translators: %s is for name.
 msgid "Search %s"
 msgstr ""
 
-#: includes/class-taxonomies.php:110 includes/class-taxonomies.php:204
-#: includes/class-taxonomies.php:275
+#: includes/class-agentpress-taxonomies.php:143
+#: includes/class-agentpress-taxonomies.php:257
+#: includes/class-agentpress-taxonomies.php:343
+#. translators: %s is for name.
 msgid "Popular %s"
 msgstr ""
 
-#: includes/class-taxonomies.php:111 includes/class-taxonomies.php:205
-#: includes/class-taxonomies.php:276
+#: includes/class-agentpress-taxonomies.php:145
+#: includes/class-agentpress-taxonomies.php:259
+#: includes/class-agentpress-taxonomies.php:345
+#. translators: %s is for name.
 msgid "All %s"
 msgstr ""
 
-#: includes/class-taxonomies.php:112 includes/class-taxonomies.php:206
-#: includes/class-taxonomies.php:277
+#: includes/class-agentpress-taxonomies.php:147
+#: includes/class-agentpress-taxonomies.php:261
+#: includes/class-agentpress-taxonomies.php:347
+#. translators: %s is for singular name.
 msgid "Edit %s"
 msgstr ""
 
-#: includes/class-taxonomies.php:113 includes/class-taxonomies.php:207
-#: includes/class-taxonomies.php:278
+#: includes/class-agentpress-taxonomies.php:149
+#: includes/class-agentpress-taxonomies.php:263
+#: includes/class-agentpress-taxonomies.php:349
+#. translators: %s is for singular name.
 msgid "Update %s"
 msgstr ""
 
-#: includes/class-taxonomies.php:114 includes/class-taxonomies.php:208
-#: includes/class-taxonomies.php:279
+#: includes/class-agentpress-taxonomies.php:151
+#: includes/class-agentpress-taxonomies.php:265
+#: includes/class-agentpress-taxonomies.php:351
+#. translators: %s is for singular name.
 msgid "Add New %s"
 msgstr ""
 
-#: includes/class-taxonomies.php:115 includes/class-taxonomies.php:209
-#: includes/class-taxonomies.php:280
+#: includes/class-agentpress-taxonomies.php:153
+#: includes/class-agentpress-taxonomies.php:267
+#: includes/class-agentpress-taxonomies.php:353
+#. translators: %s is for singular name.
 msgid "New %s Name"
 msgstr ""
 
-#: includes/class-taxonomies.php:116 includes/class-taxonomies.php:210
-#: includes/class-taxonomies.php:281
+#: includes/class-agentpress-taxonomies.php:155
+#: includes/class-agentpress-taxonomies.php:269
+#: includes/class-agentpress-taxonomies.php:355
+#. translators: %s is for name.
 msgid "Add or Remove %s"
 msgstr ""
 
-#: includes/class-taxonomies.php:117 includes/class-taxonomies.php:211
-#: includes/class-taxonomies.php:282
+#: includes/class-agentpress-taxonomies.php:157
+#: includes/class-agentpress-taxonomies.php:271
+#: includes/class-agentpress-taxonomies.php:357
+#. translators: %s is for name.
 msgid "Choose from the most used %s"
 msgstr ""
 
-#: includes/class-taxonomies.php:173
+#: includes/class-agentpress-taxonomies.php:214
 msgid ""
 "Nice try, partner. But that taxonomy doesn't exist. Click back and try "
 "again."
 msgstr ""
 
-#: includes/class-taxonomies.php:241
+#: includes/class-agentpress-taxonomies.php:306
 msgid "New taxonomy successfully created!"
 msgstr ""
 
-#: includes/class-taxonomies.php:246
+#: includes/class-agentpress-taxonomies.php:312
 msgid "Taxonomy successfully edited!"
 msgstr ""
 
-#: includes/class-taxonomies.php:251
+#: includes/class-agentpress-taxonomies.php:318
 msgid "Taxonomy successfully deleted."
 msgstr ""
 
-#: includes/views/create-tax.php:2
+#: includes/views/create-tax.php:10
 msgid "Listing Taxonomies"
 msgstr ""
 
-#: includes/views/create-tax.php:11
+#: includes/views/create-tax.php:17
 msgid "Current Listing Taxonomies"
 msgstr ""
 
-#: includes/views/create-tax.php:15 includes/views/create-tax.php:23
-#: includes/views/create-tax.php:78 includes/views/edit-tax.php:19
+#: includes/views/create-tax.php:21 includes/views/create-tax.php:29
+#: includes/views/create-tax.php:92 includes/views/edit-tax.php:27
 msgid "ID"
 msgstr ""
 
-#: includes/views/create-tax.php:16 includes/views/create-tax.php:24
-#: includes/views/create-tax.php:90 includes/views/edit-tax.php:33
+#: includes/views/create-tax.php:22 includes/views/create-tax.php:30
+#: includes/views/create-tax.php:104 includes/views/edit-tax.php:41
 msgid "Singular Name"
 msgstr ""
 
-#: includes/views/create-tax.php:17 includes/views/create-tax.php:25
-#: includes/views/create-tax.php:84 includes/views/edit-tax.php:27
+#: includes/views/create-tax.php:23 includes/views/create-tax.php:31
+#: includes/views/create-tax.php:98 includes/views/edit-tax.php:35
 msgid "Plural Name"
 msgstr ""
 
-#: includes/views/create-tax.php:51
+#: includes/views/create-tax.php:65
 msgid "Delete"
 msgstr ""
 
-#: includes/views/create-tax.php:72
+#: includes/views/create-tax.php:86
 msgid "Add New Listing Taxonomy"
 msgstr ""
 
-#: includes/views/create-tax.php:80
+#: includes/views/create-tax.php:94
 msgid ""
-"The unique ID is used to register the taxonomy.<br />(no spaces, "
-"underscores, or special characters)"
+"The unique ID is used to register the taxonomy. (no spaces, underscores, or "
+"special characters)"
 msgstr ""
 
-#: includes/views/create-tax.php:86 includes/views/edit-tax.php:29
+#: includes/views/create-tax.php:100 includes/views/edit-tax.php:37
 msgid "Example: \"Property Types\" or \"Locations\""
 msgstr ""
 
-#: includes/views/create-tax.php:92 includes/views/edit-tax.php:35
+#: includes/views/create-tax.php:106 includes/views/edit-tax.php:43
 msgid "Example: \"Property Type\" or \"Location\""
 msgstr ""
 
-#: includes/views/create-tax.php:95
+#: includes/views/create-tax.php:109
 msgid "Add New Taxonomy"
 msgstr ""
 
-#: includes/views/edit-tax.php:7
+#: includes/views/edit-tax.php:16
 msgid ""
 "Nice try, partner. But that taxonomy doesn't exist or can't be edited. "
 "Click back and try again."
 msgstr ""
 
-#: includes/views/edit-tax.php:12
+#: includes/views/edit-tax.php:20
 msgid "Edit Taxonomy"
 msgstr ""
 
-#: includes/views/edit-tax.php:23
+#: includes/views/edit-tax.php:31
 msgid "The unique ID is used to register the taxonomy. (cannot be changed)"
 msgstr ""
 
-#: includes/views/edit-tax.php:40
+#: includes/views/edit-tax.php:48
 msgid "Update"
 msgstr ""
 
-#: includes/views/listing-details-metabox.php:6
+#: includes/views/listing-details-metabox.php:12
 msgid "Custom Text: "
 msgstr ""
 
-#: includes/views/listing-details-metabox.php:7
+#: includes/views/listing-details-metabox.php:13
 msgid "Custom text shows on the featured listings widget image."
 msgstr ""
 
-#: includes/views/listing-details-metabox.php:18
-#: includes/views/listing-details-metabox.php:34
-#: includes/views/listing-details-metabox.php:42
+#: includes/views/listing-details-metabox.php:24
+#: includes/views/listing-details-metabox.php:40
+#: includes/views/listing-details-metabox.php:48
 msgid "Send to text editor"
 msgstr ""
 
-#: includes/views/listing-details-metabox.php:32
-msgid ""
-"<p><label>Enter Map Embed Code:<br /><textarea name=\"ap[_listing_map]\" "
-"rows=\"5\" cols=\"18\" style=\"%s\">%s</textarea></label></p>"
+#: includes/views/listing-details-metabox.php:38
+msgid "Enter Map Embed Code:"
 msgstr ""
 
-#: includes/views/listing-details-metabox.php:40
-msgid ""
-"<p><label>Enter Video Embed Code:<br /><textarea "
-"name=\"ap[_listing_video]\" rows=\"5\" cols=\"18\" "
-"style=\"%s\">%s</textarea></label></p>"
+#: includes/views/listing-details-metabox.php:46
+msgid "Enter Video Embed Code"
 msgstr ""
 
-#: plugin.php:33
+#: plugin.php:40
+#. translators: %1$s is the link.
 msgid ""
 "Sorry, you can't activate unless you have installed <a "
-"href=\"%s\">Genesis</a>"
+"href=\"%1$s\">Genesis</a>"
 msgstr ""
 
-#: plugin.php:41
-msgid "Sorry, you cannot activate without <a href=\"%s\">Genesis %s</a> or greater"
+#: plugin.php:62
+#. translators: %1$s is the link and %2$s is the version.
+msgid ""
+"Sorry, you cannot activate without <a href=\"%1$s\">Genesis %2$s</a> or "
+"greater"
 msgstr ""
 
 #. Plugin Name of the plugin/theme
@@ -365,7 +386,7 @@ msgid "AgentPress Listings"
 msgstr ""
 
 #. Author URI of the plugin/theme
-msgid "http://www.studiopress.com/"
+msgid "https://www.studiopress.com/"
 msgstr ""
 
 #. Description of the plugin/theme

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "uri": "https://github.com/copyblogger/agentpress-listings",
     "description": "AgentPress Listings is a plugin which adds a Listings custom post type for Real Estate agents.",
     "author": "StudioPress",
-    "authoruri": "http://www.studiopress.com/",
-    "version": "1.3.2",
-    "license": "GPL-2.0+",
-    "licenseuri": "http://www.gnu.org/licenses/gpl-2.0.html",
+    "authoruri": "https://www.studiopress.com/",
+    "version": "1.3.3",
+    "license": "GPL-2.0-or-later",
+    "licenseuri": "https://www.gnu.org/licenses/gpl-2.0.html",
     "textdomain": "agentpress-listings"
   }
 }

--- a/plugin.php
+++ b/plugin.php
@@ -6,7 +6,7 @@
  * Author: StudioPress
  * Author URI: https://www.studiopress.com/
  *
- * Version: 1.3.2
+ * Version: 1.3.3
  *
  * Text Domain: agentpress-listings
  * Domain Path: /languages/
@@ -105,7 +105,7 @@ function agentpress_listings_init() {
 	global $_agentpress_listings, $_agentpress_taxonomies;
 
 	define( 'APL_URL', plugin_dir_url( __FILE__ ) );
-	define( 'APL_VERSION', '1.3.2' );
+	define( 'APL_VERSION', '1.3.3' );
 
 	/** Load textdomain for translation */
 	load_plugin_textdomain( 'agentpress-listings', false, basename( dirname( __FILE__ ) ) . '/languages/' );

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: nathanrice, wpmuguru, studiopress, nick_thegeek, marksabbath
 Tags: real estate, agentpress, genesis, genesiswp
 Requires at least: 4.0.0
-Tested up to: 5.2.1
-Stable tag: 1.3.2
+Tested up to: 5.2.2
+Stable tag: 1.3.3
 
 This plugin adds a Listings custom post type for Real Estate agents.
 
@@ -30,6 +30,9 @@ Yes, you can use the filter agentpress_featured_listings_allowed_html.
 
 
 == Changelog ==
+
+= 1.3.3 =
+* Prevent `_listing_price_sortable` meta being removed when creating new listings or saving existing ones. If listings disappeared from your archives and search results after editing them, try updating the plugin and then resaving them.
 
 = 1.3.2 =
 * Fix a bug where map and video textarea were stripping HTML tags from the content.


### PR DESCRIPTION
Merge from develop to master ready to tag and release. Changelog:

### 1.3.3
* Prevent `_listing_price_sortable` meta being removed when creating new listings or saving existing ones. If listings disappeared from your archives and search results after editing them, try updating the plugin and then resaving them.