### PR TITLE
Allow AgentPress Listings details to save under WP 5.3.1+

### DIFF
--- a/includes/class-agentpress-listings.php
+++ b/includes/class-agentpress-listings.php
@@ -230,8 +230,8 @@ class AgentPress_Listings {
 		}
 
 		// Extra check for price that can create a sortable value.
-		if ( isset( $property_details[0]['_listing_price'] ) && ! empty( $property_details[0]['_listing_price'] ) ) {
-			$price_sortable = preg_replace( '/[^0-9\.]/', '', $property_details[0]['_listing_price'] );
+		if ( isset( $property_details['_listing_price'] ) && ! empty( $property_details['_listing_price'] ) ) {
+			$price_sortable = preg_replace( '/[^0-9\.]/', '', $property_details['_listing_price'] );
 			update_post_meta( $post_id, '_listing_price_sortable', floatval( $price_sortable ) );
 		} else {
 			delete_post_meta( $post_id, '_listing_price_sortable' );

--- a/includes/class-agentpress-listings.php
+++ b/includes/class-agentpress-listings.php
@@ -241,7 +241,8 @@ class AgentPress_Listings {
 	/**
 	 * Filter the columns in the "Listings" screen, define our own.
 	 *
-	 * @param array $columns Columns.
+	 * @param array $columns Columns data.
+	 * @return array Modified columns data.
 	 */
 	public function columns_filter( $columns ) {
 
@@ -372,6 +373,7 @@ class AgentPress_Listings {
 	 * Search templates.
 	 *
 	 * @param  array $template Template.
+	 * @return string|array The template filename or the original template data.
 	 */
 	public function search_template( $template ) {
 

--- a/includes/class-agentpress-listings.php
+++ b/includes/class-agentpress-listings.php
@@ -216,11 +216,11 @@ class AgentPress_Listings {
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$property_details = array_map( 'wp_kses', array( wp_unslash( $_POST['ap'] ) ), array( $this->allowed_tags ) );
+		$property_details = (array) wp_unslash( $_POST['ap'] );
+		array_walk( $property_details, array( $this, 'sanitize_detail' ) );
 
 		/** Store the custom fields */
-		foreach ( (array) $property_details[0] as $key => $value ) {
-
+		foreach ( (array) $property_details as $key => $value ) {
 			/** Save/Update/Delete */
 			if ( $value ) {
 				update_post_meta( $post->ID, $key, $value );
@@ -409,6 +409,16 @@ class AgentPress_Listings {
 
 		return $crumbs;
 
+	}
+
+	/**
+	 * Callback for `array_walk` to sanitize property details during save.
+	 *
+	 * @param string $detail The property meta data.
+	 * @param mixed  $key Key, unused.
+	 */
+	protected function sanitize_detail( &$detail, $key ) {
+		$detail = wp_kses( $detail, (array) $this->allowed_tags );
 	}
 
 }


### PR DESCRIPTION
**Summary of change:**
Fixes https://github.com/studiopress/agentpress-listings/issues/47, where property listing details are failing to save under WordPress 5.3.1+.

The cause was this line in `includes/class-agentpress-listings.php`:

```php
$property_details = array_map( 'wp_kses', array( wp_unslash( $_POST['ap'] ) ), array( $this->allowed_tags ) );
```

`array( wp_unslash( $_POST['ap'] )` causes the `$_POST['ap']` array to appear as the first value in another array:


```
array(1) { 
    [0]=> array(13) { 
        ["_listing_text"]=> string(23) "Custom text lives here."
        ["_listing_price"]=> string(10) "123,002123"
        etc...
```

When that array is passed to `array_map`, each array item is passed to `wp_kses`. The first and only item is the `array(13)`. Passing an array to `wp_kses` worked by accident in earlier versions of WP but not in WP 5.3.1, as reported here:

https://core.trac.wordpress.org/ticket/48955

wp_kses expects a string for the first argument and not an array:

https://developer.wordpress.org/reference/functions/wp_kses/#parameters

It is not enough to just replace `array( wp_unslash( $_POST['ap'] ) )` with `wp_unslash( $_POST['ap'] )` or `(array) wp_unslash( $_POST['ap'] )`, though, because passing that array to `array_map` will remove the keyed strings (`_listing_price` becomes `0` etc.).

This PR fixes the issue by:
- Switching to `array_walk` to retain string keys.
- Ensuring that each item in the `$_POST['ap']` array is passed to `wp_kses` individually, instead of passing all items as one array.

**Have the changes in this PR been added to the documentation for this project?**
Not required.

**How to test:**
Under WP 5.3.1:
1. Create a new listing or edit an existing one.
2. Edit values in the property details meta box.
3. Update the listing and check that your changes persist.
4. If you add a price, check that the `_listing_price_sortable` is saved:

```
❯ wp post meta list 3608
+---------+-------------------------+-------------------------------------------------+
| post_id | meta_key                | meta_value                                      |
+---------+-------------------------+-------------------------------------------------+
| 3608    | _edit_last              | 1                                               |
| 3608    | _edit_lock              | 1576499614:1                                    |
| 3608    | _listing_price          | 123,002                                         |
... removed ...
| 3608    | _listing_price_sortable | 123002                                          |
+---------+-------------------------+-------------------------------------------------+
````
5. Try entering non-allowed HTML in the fields and check that relevant tags are stripped on save. For example:

```HTML
<p>p tags should remain</p> <h1>h1 tags should be stripped, but their content retained</h1>
```

Repeat these tests with an earlier version of WordPress, such as 5.1.

**Suggested Changelog Entry:**
Ensure edited property details save under WordPress 5.3.1+.

**Notes**
I reviewed other usages of `wp_kses` and can't see that we pass it an array instead of the expected string anywhere else.