### PR TITLE
Prep for 1.3.4

### DIFF
--- a/includes/class-agentpress-listings.php
+++ b/includes/class-agentpress-listings.php
@@ -230,8 +230,8 @@ class AgentPress_Listings {
 		}
 
 		// Extra check for price that can create a sortable value.
-		if ( isset( $property_details[0]['_listing_price'] ) && ! empty( $property_details[0]['_listing_price'] ) ) {
-			$price_sortable = preg_replace( '/[^0-9\.]/', '', $property_details[0]['_listing_price'] );
+		if ( isset( $property_details['_listing_price'] ) && ! empty( $property_details['_listing_price'] ) ) {
+			$price_sortable = preg_replace( '/[^0-9\.]/', '', $property_details['_listing_price'] );
 			update_post_meta( $post_id, '_listing_price_sortable', floatval( $price_sortable ) );
 		} else {
 			delete_post_meta( $post_id, '_listing_price_sortable' );

--- a/includes/class-agentpress-listings.php
+++ b/includes/class-agentpress-listings.php
@@ -241,7 +241,8 @@ class AgentPress_Listings {
 	/**
 	 * Filter the columns in the "Listings" screen, define our own.
 	 *
-	 * @param array $columns Columns.
+	 * @param array $columns Columns data.
+	 * @return array Modified columns data.
 	 */
 	public function columns_filter( $columns ) {
 
@@ -372,6 +373,7 @@ class AgentPress_Listings {
 	 * Search templates.
 	 *
 	 * @param  array $template Template.
+	 * @return string|array The template filename or the original template data.
 	 */
 	public function search_template( $template ) {
 

--- a/includes/class-agentpress-listings.php
+++ b/includes/class-agentpress-listings.php
@@ -216,11 +216,11 @@ class AgentPress_Listings {
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$property_details = array_map( 'wp_kses', array( wp_unslash( $_POST['ap'] ) ), array( $this->allowed_tags ) );
+		$property_details = (array) wp_unslash( $_POST['ap'] );
+		array_walk( $property_details, array( $this, 'sanitize_detail' ) );
 
 		/** Store the custom fields */
-		foreach ( (array) $property_details[0] as $key => $value ) {
-
+		foreach ( (array) $property_details as $key => $value ) {
 			/** Save/Update/Delete */
 			if ( $value ) {
 				update_post_meta( $post->ID, $key, $value );
@@ -409,6 +409,16 @@ class AgentPress_Listings {
 
 		return $crumbs;
 
+	}
+
+	/**
+	 * Callback for `array_walk` to sanitize property details during save.
+	 *
+	 * @param string $detail The property meta data.
+	 * @param mixed  $key Key, unused.
+	 */
+	protected function sanitize_detail( &$detail, $key ) {
+		$detail = wp_kses( $detail, (array) $this->allowed_tags );
 	}
 
 }

--- a/languages/agentpress-listings.pot
+++ b/languages/agentpress-listings.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GNU General Public License v2.0 (or later).
 msgid ""
 msgstr ""
-"Project-Id-Version: AgentPress Listings 1.3.3\n"
+"Project-Id-Version: AgentPress Listings 1.3.4\n"
 "Report-Msgid-Bugs-To: StudioPress <translations@studiopress.com>\n"
-"POT-Creation-Date: 2019-07-11 15:33:03+00:00\n"
+"POT-Creation-Date: 2019-12-16 13:14:51+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -152,31 +152,31 @@ msgstr ""
 msgid "Property Details"
 msgstr ""
 
-#: includes/class-agentpress-listings.php:250
+#: includes/class-agentpress-listings.php:251
 msgid "Thumbnail"
 msgstr ""
 
-#: includes/class-agentpress-listings.php:251
+#: includes/class-agentpress-listings.php:252
 msgid "Listing Title"
 msgstr ""
 
-#: includes/class-agentpress-listings.php:252
+#: includes/class-agentpress-listings.php:253
 msgid "Details"
 msgstr ""
 
-#: includes/class-agentpress-listings.php:253
+#: includes/class-agentpress-listings.php:254
 msgid "Features"
 msgstr ""
 
-#: includes/class-agentpress-listings.php:254
+#: includes/class-agentpress-listings.php:255
 msgid "Categories"
 msgstr ""
 
-#: includes/class-agentpress-listings.php:332
+#: includes/class-agentpress-listings.php:333
 msgid "Additional Features:"
 msgstr ""
 
-#: includes/class-agentpress-listings.php:408
+#: includes/class-agentpress-listings.php:410
 msgid "Listing Search Results"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "description": "AgentPress Listings is a plugin which adds a Listings custom post type for Real Estate agents.",
     "author": "StudioPress",
     "authoruri": "https://www.studiopress.com/",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "license": "GPL-2.0-or-later",
     "licenseuri": "https://www.gnu.org/licenses/gpl-2.0.html",
     "textdomain": "agentpress-listings"

--- a/plugin.php
+++ b/plugin.php
@@ -6,7 +6,7 @@
  * Author: StudioPress
  * Author URI: https://www.studiopress.com/
  *
- * Version: 1.3.3
+ * Version: 1.3.4
  *
  * Text Domain: agentpress-listings
  * Domain Path: /languages/
@@ -105,7 +105,7 @@ function agentpress_listings_init() {
 	global $_agentpress_listings, $_agentpress_taxonomies;
 
 	define( 'APL_URL', plugin_dir_url( __FILE__ ) );
-	define( 'APL_VERSION', '1.3.3' );
+	define( 'APL_VERSION', '1.3.4' );
 
 	/** Load textdomain for translation */
 	load_plugin_textdomain( 'agentpress-listings', false, basename( dirname( __FILE__ ) ) . '/languages/' );

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: nathanrice, wpmuguru, studiopress, nick_thegeek, marksabbath
 Tags: real estate, agentpress, genesis, genesiswp
 Requires at least: 4.0.0
-Tested up to: 5.2.2
+Tested up to: 5.3
 Stable tag: 1.3.4
 
 This plugin adds a Listings custom post type for Real Estate agents.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, wpmuguru, studiopress, nick_thegeek, marksabbath
 Tags: real estate, agentpress, genesis, genesiswp
 Requires at least: 4.0.0
 Tested up to: 5.2.2
-Stable tag: 1.3.3
+Stable tag: 1.3.4
 
 This plugin adds a Listings custom post type for Real Estate agents.
 

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,9 @@ Yes, you can use the filter agentpress_featured_listings_allowed_html.
 
 == Changelog ==
 
+= 1.3.4 =
+* Ensure edited property details save in WordPress 5.3+.
+
 = 1.3.3 =
 * Prevent `_listing_price_sortable` meta being removed when creating new listings or saving existing ones. If listings disappeared from your archives and search results after editing them, try updating the plugin and then resaving them.
 


### PR DESCRIPTION
Fixes https://github.com/studiopress/agentpress-listings/issues/49 by completing release tasks for 1.3.4 .

Forked from https://github.com/studiopress/agentpress-listings/pull/48 so also includes those changes until that branch is merged.